### PR TITLE
Add test for default filename in Paperwork runtime

### DIFF
--- a/paperwork-runtime/src/test/java/hu/supercluster/paperwork/PaperworkTest.java
+++ b/paperwork-runtime/src/test/java/hu/supercluster/paperwork/PaperworkTest.java
@@ -1,0 +1,12 @@
+package hu.supercluster.paperwork;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class PaperworkTest {
+    @Test
+    public void testDefaultFileName() {
+        assertEquals("paperwork.json", Paperwork.DEFAULT_FILENAME);
+    }
+}


### PR DESCRIPTION
Related to #9. I'll be adding more and more tests. Though I wanna add them slowly as I'm quite busy myself right now.

This one should just remind us to never change the default name ever again.
